### PR TITLE
Add YouTube recording + other links

### DIFF
--- a/_posts/events/2017-11-29-kommunikation-software.markdown
+++ b/_posts/events/2017-11-29-kommunikation-software.markdown
@@ -9,6 +9,7 @@ speakers:
 slides: 
     name: Online auf schauderhaft.de
     url: http://blog.schauderhaft.de/communication-talk/talk.html#/
+youtube: https://youtu.be/tB0yuVb2GgE
 location: synyx
 ---
 

--- a/_posts/events/2017-11-29-spring-reactive.markdown
+++ b/_posts/events/2017-11-29-spring-reactive.markdown
@@ -9,6 +9,7 @@ speakers:
 slides: 
     name: Online auf schauderhaft.de
     url: http://blog.schauderhaft.de/spring-data-reactive-talk/talk.html#/
+youtube: https://youtu.be/x4JB-Ggc2fE
 location: synyx
 ---
 

--- a/_posts/events/2019-03-13-reactive-relational-database-connectivity.markdown
+++ b/_posts/events/2019-03-13-reactive-relational-database-connectivity.markdown
@@ -6,6 +6,7 @@ tags: events
 registration: https://www.meetup.com/de-DE/Java-User-Group-Karlsruhe/events/258235982/
 speakers:
  - mpaluch
+youtube: https://youtu.be/xioEiUbp6oE
 location: synyx
 ---
 

--- a/_posts/events/2019-04-24-wie-werde-ich-ein-erfolgreicher-softwarearchitekt.markdown
+++ b/_posts/events/2019-04-24-wie-werde-ich-ein-erfolgreicher-softwarearchitekt.markdown
@@ -6,6 +6,7 @@ tags: events
 registration: https://www.meetup.com/de-DE/Java-User-Group-Karlsruhe/events/258501099/
 speakers:
  - ewolff
+youtube: https://youtu.be/LZ85nnyAxsw
 location: synyx
 ---
 

--- a/_posts/events/2019-06-05-docs-as-code.markdown
+++ b/_posts/events/2019-06-05-docs-as-code.markdown
@@ -6,6 +6,7 @@ registration: https://www.meetup.com/de-DE/Java-User-Group-Karlsruhe/events/2612
 tags: events
 speakers:
  - rdmueller
+youtube: https://youtu.be/SZMkWAFtrz0
 location: synyx
 ---
 

--- a/_posts/events/2019-12-18-systemisch-agil.markdown
+++ b/_posts/events/2019-12-18-systemisch-agil.markdown
@@ -7,6 +7,7 @@ registration: https://www.meetup.com/de-DE/Java-User-Group-Karlsruhe/events/2669
 speakers:
  - cmennerich
  - fmeseck
+youtube: https://youtu.be/FAA31oVBrBI
 location: synyx
 ---
 

--- a/_posts/events/2020-03-31-visualisierung-soziotechnischer-architekturen.markdown
+++ b/_posts/events/2020-03-31-visualisierung-soziotechnischer-architekturen.markdown
@@ -6,6 +6,7 @@ tags: events
 registration: https://www.meetup.com/de-DE/Java-User-Group-Karlsruhe/events/268395182
 speakers:
  - mploed
+youtube: https://youtu.be/miu8KcSrkps
 links:
  - https://innoq.zoom.us/j/819366191
 ---

--- a/_posts/events/2020-03-31-visualisierung-soziotechnischer-architekturen.markdown
+++ b/_posts/events/2020-03-31-visualisierung-soziotechnischer-architekturen.markdown
@@ -7,8 +7,6 @@ registration: https://www.meetup.com/de-DE/Java-User-Group-Karlsruhe/events/2683
 speakers:
  - mploed
 youtube: https://youtu.be/miu8KcSrkps
-links:
- - https://innoq.zoom.us/j/819366191
 ---
 
 **Aus Rücksicht auf die aktuelle Lage (Coronavirus / COVID-19) wird der Vortrag gestreamt. Den Link zum Meeting findet Ihr oben.**

--- a/_posts/events/2025-04-09-zero-to-opentelemetry.markdown
+++ b/_posts/events/2025-04-09-zero-to-opentelemetry.markdown
@@ -7,7 +7,10 @@ tags: events
 speakers:
 - mmichele
 location: synyx-glas
-youtube: https://www.youtube.com/@SynyxDe/live
+youtube: https://youtu.be/c6_3of2Y9e8
+links:
+- https://opentelemetry.io/
+- https://www.dash0.com/
 ---
 
 In this talk, Michele will tell you what you need to know to start your Observability journey with OpenTelemetry with JVM-based applications on Kubernetes, (Virtual) machines and other platforms.


### PR DESCRIPTION
Initially just contained the YouTube + two other links for the _Zero to OpenTelemetry_ talk. But I noticed a few JUG videos on the synyx YouTube channel that were not referenced and completed the list.